### PR TITLE
No strangers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Find Data Beta
 
 
+In order for the app to work, you need to set two environment variables:
+`FIND_USERNAME` and `FIND_PASSWORD`. They need to be set in order to be able to
+log in.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,13 @@
 class ApplicationController < ActionController::Base
-  httpauth_name = ENV.fetch('FIND_USERNAME', rand(100000000).to_s)
-  httpauth_pass = ENV.fetch('FIND_PASSWORD', rand(100000000).to_s)
-  http_basic_authenticate_with name: httpauth_name, password: httpauth_pass
+  before_action :authenticate
   protect_from_forgery with: :exception
+end
+
+
+def authenticate
+  httpauth_name = ENV['FIND_USERNAME']
+  httpauth_pass = ENV['FIND_PASSWORD']
+  authenticate_or_request_with_http_basic('Administration') do |username, password|
+    username == httpauth_name && password == httpauth_pass
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,6 @@
 class ApplicationController < ActionController::Base
+  httpauth_name = ENV.fetch('FIND_USERNAME', rand(100000000).to_s)
+  httpauth_pass = ENV.fetch('FIND_PASSWORD', rand(100000000).to_s)
+  http_basic_authenticate_with name: httpauth_name, password: httpauth_pass
   protect_from_forgery with: :exception
 end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,3 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /
+


### PR DESCRIPTION
Because we want to mandate HTTP auth, we set defaults to be long numbers. There's probably a clearer way to do it. Suggestions welcome.