### PR TITLE
Bug fix on dataset show page

### DIFF
--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -53,21 +53,13 @@ module DatasetsHelper
     start_dates.uniq.length > 1
   end
 
-  def has_start_dates?(dataset)
-    if dataset['datafiles'].any?
-      dataset['datafiles'].reject do |file|
-        file["start_date"].nil?
-      end.map {|file| file}.any?
-    end
-  end
-
   def group_by_year(datasets)
     datasets_with_year = datasets.map do |dataset|
-      dataset['start_year'] = Time.parse(dataset['start_date']).year.to_s
+      dataset['start_year'] =
+          dataset['start_date'] ? Time.parse(dataset['start_date']).year.to_s : ''
       dataset
     end
-
-    datasets_with_year.group_by {|dataset| dataset['start_year']}
+    Hash[datasets_with_year.group_by {|dataset| dataset['start_year']}.sort.reverse]
   end
 
   private

--- a/app/views/datasets/_timeseries_data.html.erb
+++ b/app/views/datasets/_timeseries_data.html.erb
@@ -8,7 +8,7 @@
         </h2>
         <div class="breaker"></div>
         <ul>
-          <% group_by_year(@dataset['datafiles']).each do |year, datafiles| %>
+          <% group_by_year(@dataset.datafiles).each do |year, datafiles| %>
             <li class="showHide">
               <div class="year-expand showHide-control">
                 <h3 class="heading-small">
@@ -32,18 +32,18 @@
                   <% datafiles.each do |datafile| %>
                     <tr>
                       <td class="title small">
-                        <% if datafile[:name] %> <%= datafile[:name] %>
+                        <% if datafile['name'] %> <%= datafile['name'] %>
                         <% else %> Data Link
                         <% end %>
                       </td>
-                      <% if datafile[:format] %>
-                        <td> datafile.format (347kb)</td>
+                      <% if datafile['format'] %>
+                        <td><%= datafile['format'] %> (347kb)</td>
                       <% else %>
                         <td>N/A</td>
                       <% end %>
-                      <% if datafile[:last_updated] %>
+                      <% if datafile['last_updated'] %>
                         <td>
-                          datafile.last_updated
+                          <%= datafile['last_updated'] %>
                         </td>
                       <% else %>
                         <td class="not-available">

--- a/spec/helpers/datasets_helper_spec.rb
+++ b/spec/helpers/datasets_helper_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 describe DatasetsHelper, type: :helper do
-  it 'Should group time series data by year' do
+  it 'groups time series data by year' do
     expect(helper.group_by_year(UNFORMATTED_DATASETS_MULTIYEAR)).to eql FORMATTED_DATASETS
   end
 
-  it 'should return true if the dataset has data files from from more than one year' do
+  it 'returns true if the dataset has data files from from more than one year' do
     expect(helper.timeseries_data?(UNFORMATTED_DATASETS_MULTIYEAR)).to be true
   end
 
-  it 'should return false if the dataset has data files from the same year' do
+  it 'returns false if the dataset has data files from the same year' do
     expect(helper.timeseries_data?(UNFORMATTED_DATASETS_SINGLEYEAR)).to be false
   end
 end

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -137,6 +137,13 @@ UNFORMATTED_DATASETS_MULTIYEAR = [
      'start_date' => '2015-09-24',
      'end_date' => nil,
      'updated_at' => '2015-08-31T14:40:57.528Z'
+    },
+    {'id' => 4,
+     'name' => 'Dataset 4',
+     'url' => 'https://good_data.co.uk',
+     'start_date' => nil,
+     'end_date' => nil,
+     'updated_at' => '2015-10-31T14:40:57.528Z'
     }]
 
 UNFORMATTED_DATASETS_SINGLEYEAR = [
@@ -186,5 +193,13 @@ FORMATTED_DATASETS = {
                 'end_date' => nil,
                 'updated_at' => '2015-08-31T14:40:57.528Z',
                 'start_year' => '2015'
-               }]
+               }],
+        "" => [{'id' => 4,
+         'name' => 'Dataset 4',
+         'url' => 'https://good_data.co.uk',
+         'start_date' => nil,
+         'end_date' => nil,
+         'updated_at' => '2015-10-31T14:40:57.528Z',
+         'start_year' => ''
+        }]
 }


### PR DESCRIPTION
- fixes template to use ES DSL syntax, ie `dataset.datafiles` instead of `dataset['datafiles']`
- removes unused method from datasets_helper
- handles datasets that contain BOTH time series datafiles and datafiles that have nil start date.
- adds specs
- fixes display of time series data so that the year groups are ordered most recent first
eg: http://localhost:3000/dataset/land-registry-monthly-price-paid-data

