### PR TITLE
Don't send GET requests with payloads

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -7,7 +7,8 @@ config = {
     request: {
       timeout: ELASTIC_CONFIG['transport_options']['request']['timeout']
     }
-  }
+  },
+  send_get_body_as: 'POST'
 }
 
 ELASTIC = Elasticsearch::Client.new(config)


### PR DESCRIPTION
Don't send GET requests with payloads, as some proxies discard them