### PR TITLE
Boost location and organisation in related dataset results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## 2017-08-11
 * Added changelog
 * Added contributors list and contribution instructions
+* Tweak location and organisation scoring in search results

--- a/app/helpers/query_builder.rb
+++ b/app/helpers/query_builder.rb
@@ -17,7 +17,7 @@ module QueryBuilder
   end
 
   def related_to_query(id)
-    query = {
+    {
       size: 4,
       query: {
         dis_max: {
@@ -49,8 +49,6 @@ module QueryBuilder
         }
       }
     }
-
-    query
   end
 
   def search_query(params)

--- a/app/helpers/query_builder.rb
+++ b/app/helpers/query_builder.rb
@@ -17,20 +17,40 @@ module QueryBuilder
   end
 
   def related_to_query(id)
-    {
+    query = {
       size: 4,
       query: {
-        more_like_this: {
-          fields: %w(title summary description organisation^2 location*^2),
-          like: {
-            _type: "dataset",
-            _id: id
-          },
-          min_term_freq: 1,
-          min_doc_freq: 1
+        dis_max: {
+          queries: [
+            {
+              more_like_this: {
+                fields: %w(title summary description),
+                like: {
+                  _type: "dataset",
+                  _id: id
+                },
+                min_term_freq: 1,
+                min_doc_freq: 1
+              }
+            },
+            {
+              more_like_this: {
+                fields: %w(organisation^2 location*^2),
+                like: {
+                  _type: "dataset",
+                  _id: id
+                },
+                boost: 20,
+                min_term_freq: 1,
+                min_doc_freq: 1
+              }
+            }
+          ]
         }
       }
     }
+
+    query
   end
 
   def search_query(params)
@@ -47,7 +67,7 @@ module QueryBuilder
 
     case sort_param
       when "recent"
-        query[:sort] = { "updated_at": { "order": "desc" }}
+        query[:sort] = {"updated_at": {"order": "desc"}}
     end
 
     unless publisher_param.blank?

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -11,7 +11,7 @@ feature 'Dataset page', elasticsearch: true do
   feature 'Meta data' do
     scenario 'Display a location if there is one' do
       dataset = DatasetBuilder.new
-                    .build
+                  .build
 
       index_and_visit(dataset)
 
@@ -22,8 +22,8 @@ feature 'Dataset page', elasticsearch: true do
   feature 'Datalinks' do
     scenario 'displays if required fields present' do
       dataset = DatasetBuilder.new
-                    .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
-                    .build
+                  .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+                  .build
 
       index_and_visit(dataset)
 
@@ -32,7 +32,7 @@ feature 'Dataset page', elasticsearch: true do
 
     scenario 'do not display if datafiles are not present' do
       dataset = DatasetBuilder.new
-                    .build
+                  .build
 
       index_and_visit(dataset)
 
@@ -41,8 +41,8 @@ feature 'Dataset page', elasticsearch: true do
 
     scenario 'display if some information is missing' do
       dataset = DatasetBuilder.new
-                    .with_datafiles(DATAFILES_WITHOUT_START_AND_ENDDATE)
-                    .build
+                  .with_datafiles(DATAFILES_WITHOUT_START_AND_ENDDATE)
+                  .build
 
       index_and_visit(dataset)
 
@@ -52,42 +52,92 @@ feature 'Dataset page', elasticsearch: true do
 
   feature 'Related datasets' do
     scenario 'displays related datasets if there is a match' do
-      first_id = 1
-      second_id = 2
-      first_dataset_title = '1 Data Set'
-      first_dataset_slug = 'first-dataset-data'
-      second_dataset_title = '2 Data Set'
-      second_dataset_slug = 'second-dataset-data'
+      ID_1 = 1
+      ID_2 = 2
+      TITLE_1 = '1 Data Set'
+      TITLE_2 = '2 Data Set'
+      SLUG_1 = 'first-dataset-data'
+      SLUG_2 = 'second-dataset-data'
 
       first_dataset = DatasetBuilder.new
-                          .with_title(first_dataset_title)
-                          .with_name(first_dataset_slug)
-                          .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
-                          .build
+                        .with_title(TITLE_1)
+                        .with_name(SLUG_1)
+                        .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+                        .build
 
       second_dataset = DatasetBuilder.new
-                          .with_title(second_dataset_title)
-                          .with_name(second_dataset_slug)
-                          .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
-                          .build
+                         .with_title(TITLE_2)
+                         .with_name(SLUG_2)
+                         .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+                         .build
 
-      index_data_with_id(first_dataset, first_id)
-      index_data_with_id(second_dataset, second_id)
+      index_data_with_id(first_dataset, ID_1)
+      index_data_with_id(second_dataset, ID_2)
 
       refresh_index
 
-      visit("/dataset/#{first_dataset_slug}")
+      visit("/dataset/#{SLUG_1}")
 
       expect(page).to have_content('Related datasets')
-      expect(page).to have_content(second_dataset_title)
+      expect(page).to have_content(TITLE_2)
+    end
+
+    fscenario 'displays filtered related datasets if filters form part of search query' do
+      ID_1 = 1
+      ID_2 = 2
+      ID_3 = 3
+      TITLE_1 = 'First Dataset Data'
+      TITLE_2 = 'Second Dataset Data'
+      TITLE_3 = 'Completely unrelated'
+      SLUG_1 = 'first-dataset-data'
+      SLUG_2 = 'second-dataset-data'
+      SLUG_3 = 'completely-unrelated'
+      LONDON = 'London'
+      AUCKLAND = 'Auckland'
+
+      first_dataset = DatasetBuilder.new
+                        .with_title(TITLE_1)
+                        .with_name(SLUG_1)
+                        .with_location(LONDON)
+                        .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+                        .build
+
+      second_dataset = DatasetBuilder.new
+                         .with_title(TITLE_2)
+                         .with_name(SLUG_2)
+                         .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+                         .with_location(LONDON)
+                         .build
+
+      third_dataset = DatasetBuilder.new
+                        .with_title(TITLE_3)
+                        .with_name(SLUG_3)
+                        .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+                        .with_summary('Nothing')
+                        .with_description('Nothing')
+                        .with_location(AUCKLAND)
+                        .with_publisher('Unrelated publisher')
+                        .build
+
+      index_data_with_id(first_dataset, ID_1)
+      index_data_with_id(second_dataset, ID_2)
+      index_data_with_id(third_dataset, ID_3)
+
+      refresh_index
+
+      visit("/dataset/#{SLUG_1}")
+
+      expect(page).to have_content('Related datasets')
+      expect(page).to have_content(TITLE_2)
+      expect(page).to_not have_content(TITLE_3)
     end
 
     scenario 'does not display if related datasets is empty' do
       allow(Dataset).to receive(:related).and_return([])
 
       dataset = DatasetBuilder.new
-                    .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
-                    .build
+                  .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+                  .build
 
       index_and_visit(dataset)
 
@@ -99,9 +149,9 @@ feature 'Dataset page', elasticsearch: true do
     scenario 'Is displayed if available' do
       notes = 'Some very interesting notes'
       dataset = DatasetBuilder.new
-                    .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
-                    .with_notes(notes)
-                    .build
+                  .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+                  .with_notes(notes)
+                  .build
 
       index_and_visit(dataset)
 
@@ -111,8 +161,8 @@ feature 'Dataset page', elasticsearch: true do
 
     scenario 'Is not displayed if not available' do
       dataset = DatasetBuilder.new
-                    .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
-                    .build
+                  .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+                  .build
 
       index_and_visit(dataset)
 
@@ -124,9 +174,9 @@ feature 'Dataset page', elasticsearch: true do
     scenario 'Is displayed if available' do
       contact_email = 'contact@somewhere.com'
       dataset = DatasetBuilder.new
-                    .with_contact_email(contact_email)
-                    .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
-                    .build
+                  .with_contact_email(contact_email)
+                  .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+                  .build
 
       index_and_visit(dataset)
 
@@ -136,8 +186,8 @@ feature 'Dataset page', elasticsearch: true do
 
     scenario 'Is not displayed if not available' do
       dataset = DatasetBuilder.new
-                    .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
-                    .build
+                  .with_datafiles(DATA_FILES_WITH_START_AND_ENDDATE)
+                  .build
 
       index_and_visit(dataset)
 

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -64,6 +64,21 @@ class DatasetBuilder
     self
   end
 
+  def with_location(location)
+    @dataset[:location1] = location
+    self
+  end
+
+  def with_summary(summary)
+    @dataset[:summary] = summary
+    self
+  end
+
+  def with_description(description)
+    @dataset[:description] = description
+    self
+  end
+
   def with_notes(notes)
     @dataset[:notes] = notes
     self
@@ -71,6 +86,12 @@ class DatasetBuilder
 
   def updated_at(date_string)
     @dataset[:updated_at] = date_string
+    self
+  end
+
+  def with_publisher(publisher)
+    @dataset[:organisation][:name] = publisher
+    @dataset[:organisation][:title] = publisher
     self
   end
 


### PR DESCRIPTION
Keen for comments on this. 

This is a fine tuning of the related datasets results - those datasets that have the same publisher name or location will be scored higher. 

Note that this is not a filtering query and the results are determined based on scoring (hence there is a chance you could have a related dataset returned from another publisher, however this should be scored lower and appear lower down in the results) - hence the request for feedback.

If we want to explicitly filter datasets by any query filters then we would need to pass the filter values to the datasets controller - I'm not sure whether this is more valuable based on the limited feedback obtained so far

Code climate hates me @govuklaurence 