### PR TITLE
Use new dataset date attribute (last_updated_at instead of updated_at)

### DIFF
--- a/app/helpers/query_builder.rb
+++ b/app/helpers/query_builder.rb
@@ -65,7 +65,7 @@ module QueryBuilder
 
     case sort_param
       when "recent"
-        query[:sort] = {"updated_at": {"order": "desc"}}
+        query[:sort] = {"last_updated_at": {"order": "desc"}}
     end
 
     unless publisher_param.blank?

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -15,7 +15,7 @@ class Dataset
   attr_accessor :name, :title, :summary, :description,
                 :location1, :location2, :location3,
                 :licence, :licence_other, :frequency,
-                :published_date, :updated_at, :created_at,
+                :published_date, :last_updated_at, :created_at,
                 :harvested, :uuid, :organisation, :datafiles,
                 :inspire_dataset, :json, :notes,
                 :_index, :_type, :_id, :_score, :_source,

--- a/app/views/datasets/_meta_data.html.erb
+++ b/app/views/datasets/_meta_data.html.erb
@@ -11,7 +11,7 @@
           <dt>Published by:</dt>
           <dd><%= link_to @dataset.organisation['title'], search_path(publisher: @dataset.organisation['title']) %></dd>
           <dt>Last updated:</dt>
-          <dd><%= format(@dataset.updated_at) %></dd>
+          <dd><%= format(@dataset.last_updated_at) %></dd>
           <dt>Expected update:</dt>
           <% if @dataset.datafiles.any? %>
             <dd class="<%= expected_update_class_for(@dataset.frequency) %>">

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -50,7 +50,7 @@
                 <dt>Published by:</dt>
                 <dd><%= link_to d.organisation['title'], search_path(publisher: d.organisation['title']) %></dd>
                 <dt>Last updated:</dt>
-                <dd><%= format(d.updated_at) %></dd>
+                <dd><%= format(d.last_updated_at) %></dd>
                 <dt>Geographical area:</dt>
                 <% if d.location1.present? %>
                   <dd><%= d.location1 %></dd>

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -31,13 +31,13 @@ feature 'Search page', elasticsearch: true do
     old_dataset = DatasetBuilder.new
                     .with_title('Old Interesting Dataset')
                     .with_name('old-dataset')
-                    .updated_at('2014-07-24T14:47:25.975Z')
+                    .last_updated_at('2014-07-24T14:47:25.975Z')
                     .build
 
     new_dataset = DatasetBuilder.new
                     .with_title('Recent Interesting Dataset')
                     .with_name('new-dataset')
-                    .updated_at('2017-07-24T14:47:25.975Z')
+                    .last_updated_at('2017-07-24T14:47:25.975Z')
                     .build
 
     index([old_dataset, new_dataset])

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -14,7 +14,7 @@ class DatasetBuilder
         published_date: '2013-08-31T00:56:15.435Z',
         harvested: false,
         created_at: '2013-08-31T00:56:15.435Z',
-        updated_at: '2017-07-24T14:47:25.975Z',
+        last_updated_at: '2017-07-24T14:47:25.975Z',
         uuid: '67436432-07c3-4964-a365-5eb58d68a152',
         organisation: {
             id: 582,
@@ -84,8 +84,8 @@ class DatasetBuilder
     self
   end
 
-  def updated_at(date_string)
-    @dataset[:updated_at] = date_string
+  def last_updated_at(date_string)
+    @dataset[:last_updated_at] = date_string
     self
   end
 


### PR DESCRIPTION
This is the front end part of the fix for #145 . We are reading from the new field `last_updated_at` which contains the value stored in `metadata_modified` on the legacy dataset