### PR TITLE
Add facility for generating passwords for private beta users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
 
 * Create empty state for dataset location and last updated (#151)
 * Download or View depending if link is HTML or other (#147)
+* Add a login facility for private beta users

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require 'private_beta_user'
+
 class ApplicationController < ActionController::Base
   before_action :authenticate
   protect_from_forgery with: :exception
@@ -9,9 +11,14 @@ def authenticate
   httpauth_name = ENV['HTTP_USERNAME']
   httpauth_pass = ENV['HTTP_PASSWORD']
 
-  return unless httpauth_name && httpauth_pass
-
   authenticate_or_request_with_http_basic('Administration') do |username, password|
-    username == httpauth_name && password == httpauth_pass
+    admin_login = username == httpauth_name && password == httpauth_pass
+    beta_login = PrivateBetaUser.authenticate?(username, password)
+
+    if beta_login
+      session[:beta_user] = username
+    end
+
+    admin_login || beta_login
   end
 end

--- a/lib/private_beta_user.rb
+++ b/lib/private_beta_user.rb
@@ -1,0 +1,61 @@
+module PrivateBetaUser
+  BLACKLIST = ENV.fetch('PRIVATE_BETA_USER_BLACKLIST', '').split(';')
+  SALT = ENV.fetch("PRIVATE_BETA_USER_SALT", '')
+
+  MEMORABLE_WORDS = {
+    'a' => 'alpha',
+    'b' => 'bravo',
+    'c' => 'charlie',
+    'd' => 'delta',
+    'e' => 'echo',
+    'f' => 'foxtrot',
+    'g' => 'golf',
+    'h' => 'hotel',
+    'i' => 'india',
+    'j' => 'juliet',
+    'k' => 'kilo',
+    'l' => 'lima',
+    'm' => 'mike',
+    'n' => 'november',
+    'o' => 'oscar',
+    'p' => 'papa',
+    'q' => 'quebec',
+    'r' => 'romeo',
+    's' => 'sierra',
+    't' => 'tango',
+    'u' => 'uniform',
+    'v' => 'victor',
+    'w' => 'whiskey',
+    'x' => 'xray',
+    'y' => 'yankee',
+    'z' => 'zulu',
+    '0' => 'zero',
+    '1' => 'one',
+    '2' => 'two',
+    '3' => 'three',
+    '4' => 'four',
+    '5' => 'five',
+    '6' => 'six',
+    '7' => 'seven',
+    '8' => 'eight',
+    '9' => 'nine',
+    '-' => 'dash',
+    '/' => 'dot'
+  }
+
+  def generate(username)
+    s = Digest::SHA256
+    hash = s.base64digest(SALT + username).downcase
+    hash[0,8].split('').map { |c| MEMORABLE_WORDS[c] }.join(' ')
+  end
+
+  def authenticate?(username, password)
+    (generate(username) == password) && !blacklisted?(username)
+  end
+
+  def blacklisted?(username)
+    BLACKLIST.include?(username)
+  end
+
+  module_function :generate, :authenticate?, :blacklisted?
+end

--- a/lib/tasks/new_user.rake
+++ b/lib/tasks/new_user.rake
@@ -1,0 +1,7 @@
+require 'private_beta_user' 
+
+namespace :user do
+  task :generate, [:username] => :environment do |t, args|
+    puts PrivateBetaUser.generate(args[:username])
+  end
+end


### PR DESCRIPTION
This adds a 'password' generator for private beta users. It's not actually a password at all, it's just a hash that's easy to read.

You can get the 'password' for any username by running:
`rails user:generate[username]`

This will be taken out before public beta launches - it's not meant to secure the beta, just keep google and random others from accidentally getting to it. This is not a secure facility and should not be considered as such.

Example usage (run with no salt):
```
$ rails user:generate[laurence]
uniform india juliet eight echo papa delta zulu
```

You should set a salt when running in a staging or prod env (so that people can't use their own machines to generate passwords):
```
$ export PRIVATE_BETA_USER_SALT=my_super_secret_salt
```

You can blacklist users as well
```
$ export PRIVATE_BETA_USER_BLACKLIST=laurence;max;jess
```
and those users won't be able to log in, even with the right 'password'.