### PR TITLE
Preview styling

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -294,6 +294,12 @@ section .year-expand {
   }
 }
 
+.datafiles {
+  &__preview {
+    width: 5em;
+  }
+}
+
 // Search results page _______________________________
 
 // Pagination

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -312,3 +312,26 @@ section .year-expand {
 .result {
   margin-top: 30px;
 }
+
+// preview page
+
+section.table__preview {
+  margin-top: 40px;
+  table {
+    border: 2px solid #DEE0E2;
+    background: #fff;
+    th, td {
+      padding-left: 20px;
+      padding-right: 20px;
+    }
+    th, tr:nth-child(2n) {
+      background-color: #F8F8F8;
+    }
+    tr td {
+      border-bottom: none;
+    }
+  }
+  ul.pagination {
+    margin-left: 0;
+  }
+}

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -147,6 +147,9 @@
 }
 
 .data-links {
+  th {
+    white-space: nowrap;
+  }
   th, td {
     font-size: 16px;
   }

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -4,7 +4,7 @@ class DatasetsController < ApplicationController
 
   def show
     begin
-      query = get_query(params[:name])
+      query = get_query(name: params[:name])
       @dataset = Dataset.get(query)
       raise 'Metadata missing' if @dataset.title.blank?
     rescue => e
@@ -23,6 +23,11 @@ class DatasetsController < ApplicationController
     @preview = JSON.parse(RestClient.get(preview_url(params[:file_id])))
     @content_type = @preview.fetch('content', {}).fetch('type', '')
     @content_type = @content_type.upcase
+    dataset_id = @preview['meta']['dataset_id']
+    query = get_query(id: dataset_id)
+    @dataset = Dataset.get(query)
+
+
   rescue => e
     logger.warn("Error while displaying preview: #{e}")
   end

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -23,10 +23,7 @@ class DatasetsController < ApplicationController
     @preview = JSON.parse(RestClient.get(preview_url(params[:file_id])))
     @content_type = @preview.fetch('content', {}).fetch('type', '')
     @content_type = @content_type.upcase
-    dataset_id = @preview['meta']['dataset_id']
-    query = get_query(id: dataset_id)
-    @dataset = Dataset.get(query)
-
+    @dataset = request_dataset(@preview)
 
   rescue => e
     logger.warn("Error while displaying preview: #{e}")
@@ -49,4 +46,11 @@ class DatasetsController < ApplicationController
       referer_query if referer_host == app_host
     end
   end
+
+  def request_dataset(preview)
+    dataset_id = preview['meta']['dataset_id']
+    query = get_query(id: dataset_id)
+    Dataset.get(query)
+  end
+
 end

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -1,5 +1,4 @@
 module DatasetsHelper
-# include Rails.application.routes.url_helpers
 
   FREQUENCIES = {
       'annual' => {years: 1},
@@ -73,12 +72,12 @@ module DatasetsHelper
     (datafile["format"].blank? || datafile["format"] == 'HTML') ? 'View' : 'Download'
   end
 
-  def preview_exists?(datafile)
+  def preview_exists?(url)
     begin
-    response = RestClient.get(preview_url(datafile['id']))
-    !response.body.empty?
+      response = RestClient.get(url)
+      !response.body.empty?
     rescue
-      false
+      'no preview available'
     end
   end
   private

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -68,11 +68,25 @@ module DatasetsHelper
     Hash[datasets_with_year.group_by {|dataset| dataset['start_year']}.sort.reverse]
   end
 
-  def format_button(datafile)
-    (datafile["format"].blank? || datafile["format"] == 'HTML') ? 'View' : 'Download'
+  def link_type(datafile)
+    if datafile["format"].upcase == 'HTML'
+      :html
+    elsif check_preview(datafile['url']) == 'no preview available'
+      :no_preview
+    elsif datafile["format"].blank?
+      :unknown
+    else
+      :preview
+    end
   end
 
-  def preview_exists?(url)
+  def name_of(dataset)
+    dataset._source['name']
+  end
+
+  private
+
+  def check_preview(url)
     begin
       response = RestClient.get(url)
       !response.body.empty?
@@ -80,12 +94,6 @@ module DatasetsHelper
       'no preview available'
     end
   end
-
-  def name_of(dataset)
-    dataset._source['name']
-  end
-  
-  private
 
   def datafile_next_updated(dataset)
     freq = dataset.frequency

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -80,6 +80,11 @@ module DatasetsHelper
       'no preview available'
     end
   end
+
+  def name_of(dataset)
+    dataset._source['name']
+  end
+  
   private
 
   def datafile_next_updated(dataset)

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -69,14 +69,12 @@ module DatasetsHelper
   end
 
   def link_type(datafile)
-    if datafile["format"].upcase == 'HTML'
+    if datafile["format"].blank? || datafile["format"].upcase == 'CSV'
+      check_preview(datafile['url']) ? :preview : :no_preview
+    elsif datafile["format"].upcase == 'HTML'
       :html
-    elsif check_preview(datafile['url']) == 'no preview available'
-      :no_preview
-    elsif datafile["format"].blank?
-      :unknown
     else
-      :preview
+      :unknown
     end
   end
 

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -1,4 +1,5 @@
 module DatasetsHelper
+# include Rails.application.routes.url_helpers
 
   FREQUENCIES = {
       'annual' => {years: 1},
@@ -72,6 +73,14 @@ module DatasetsHelper
     (datafile["format"].blank? || datafile["format"] == 'HTML') ? 'View' : 'Download'
   end
 
+  def preview_exists?(datafile)
+    begin
+    response = RestClient.get(preview_url(datafile['id']))
+    !response.body.empty?
+    rescue
+      false
+    end
+  end
   private
 
   def datafile_next_updated(dataset)

--- a/app/helpers/query_builder.rb
+++ b/app/helpers/query_builder.rb
@@ -2,14 +2,14 @@ require 'uri'
 
 module QueryBuilder
 
-  def get_query(name)
+  def get_query(name:'', id: '')
+    key_value_pair =
+      name.empty? ? { _id: id } : { name: name }
     {
       query: {
         constant_score: {
           filter: {
-            term: {
-              name: name
-            }
+            term: key_value_pair
           }
         }
       }

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -4,7 +4,7 @@
     <th>Format</th>
     <th>Last updated</th>
     <th> </th>
-    <th> </th>
+    <th>Preview </th>
   </tr>
   <tbody>
     <% @dataset.datafiles.each do |datafile| %>
@@ -30,9 +30,13 @@
               <%=format_button(datafile) %>
             </a>
           </td>
+          <% if preview_exists?(datafile) %>
           <td>
-            <a href="<%= file_preview_url(datafile['id']) %>"></a>
+            <a href="<%= file_preview_url(datafile['id']) %>">Preview</a>
           </td>
+          <% else %>
+          <td class="unavailable">Not available</td>
+          <% end %>
         </tr>
       <% end %>
   </tbody>

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -1,23 +1,27 @@
-<table>
+<table class = 'datafiles'>
   <tr>
     <th class="title small">Link to the data</th>
     <th>Format</th>
     <th>Last updated</th>
-    <th> </th>
-    <th>Preview </th>
+    <th>Data preview</th>
   </tr>
   <tbody>
     <% @dataset.datafiles.each do |datafile| %>
       <tr>
         <td class="title small">
-          <% if datafile['name'] %> <%= datafile['name'] %>
-          <% else %> Data Link
-          <% end %>
+          <%= link_to (datafile['name'] ? datafile['name'] : 'Data Link'),
+              datafile['url'],
+              :data => {:'ga-event' => "datafile-download"}
+          %>
         </td>
         <%if datafile['format'].blank? %>
           <td class="unavailable">N/A</td>
         <% else %>
-          <td><%= datafile['format'].upcase %></td>
+          <td><%= datafile['format'].upcase %>
+          <% if datafile['size'] %>
+            (<%= datafile['size'] %> kB)
+          <% end %>
+          </td>
         <% end %>
 
         <% if datafile['updated_at'].present? %>
@@ -25,18 +29,13 @@
         <% else %>
           <td class="unavailable">Not available</td>
         <% end %>
-          <td>
-            <a href="<%= datafile['url'] %>" data-ga-event="datafile-download">
-              <%=format_button(datafile) %>
-            </a>
+          <td class="datafiles__preview">
+            <% if link_type(datafile) == :html %>
+              <%= link_to 'Go to site', datafile['url'] %>
+            <% else %>
+              <span class="unavailable">Not available</span>
+            <% end %>
           </td>
-          <% if preview_exists?(datafile) == "no preview available" %>
-            <td class="unavailable">Unavailable</td>
-          <% else %>
-            <td>
-              <a href="<%= file_preview_url(datafile['id']) %>">Preview</a>
-            </td>
-          <% end %>
         </tr>
       <% end %>
   </tbody>

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -1,0 +1,39 @@
+<table>
+  <tr>
+    <th class="title small">Link to the data</th>
+    <th>Format</th>
+    <th>Last updated</th>
+    <th> </th>
+    <th> </th>
+  </tr>
+  <tbody>
+    <% @dataset.datafiles.each do |datafile| %>
+      <tr>
+        <td class="title small">
+          <% if datafile['name'] %> <%= datafile['name'] %>
+          <% else %> Data Link
+          <% end %>
+        </td>
+        <%if datafile['format'].blank? %>
+          <td class="unavailable">N/A</td>
+        <% else %>
+          <td><%= datafile['format'].upcase %></td>
+        <% end %>
+
+        <% if datafile['updated_at'].present? %>
+          <td><%= format(datafile['updated_at']) %></td>
+        <% else %>
+          <td class="unavailable">Not available</td>
+        <% end %>
+          <td>
+            <a href="<%= datafile['url'] %>" data-ga-event="datafile-download">
+              <%=format_button(datafile) %>
+            </a>
+          </td>
+          <td>
+            <a href="<%= file_preview_url(datafile['id']) %>"></a>
+          </td>
+        </tr>
+      <% end %>
+  </tbody>
+</table>

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -30,13 +30,13 @@
               <%=format_button(datafile) %>
             </a>
           </td>
-          < if preview_exists?(datafile) == "no preview available" %>
+          <% if preview_exists?(datafile) == "no preview available" %>
             <td class="unavailable">Not available</td>
-          < else %>
+          <% else %>
             <td>
               <a href="<%= file_preview_url(datafile['id']) %>">Preview</a>
             </td>
-          < end %>
+          <% end %>
         </tr>
       <% end %>
   </tbody>

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -30,13 +30,13 @@
               <%=format_button(datafile) %>
             </a>
           </td>
-          <% if preview_exists?(datafile) %>
-          <td>
-            <a href="<%= file_preview_url(datafile['id']) %>">Preview</a>
-          </td>
-          <% else %>
-          <td class="unavailable">Not available</td>
-          <% end %>
+          < if preview_exists?(datafile) == "no preview available" %>
+            <td class="unavailable">Not available</td>
+          < else %>
+            <td>
+              <a href="<%= file_preview_url(datafile['id']) %>">Preview</a>
+            </td>
+          < end %>
         </tr>
       <% end %>
   </tbody>

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -31,7 +31,7 @@
             </a>
           </td>
           <% if preview_exists?(datafile) == "no preview available" %>
-            <td class="unavailable">Not available</td>
+            <td class="unavailable">Unavailable</td>
           <% else %>
             <td>
               <a href="<%= file_preview_url(datafile['id']) %>">Preview</a>

--- a/app/views/datasets/_non_timeseries_data.html.erb
+++ b/app/views/datasets/_non_timeseries_data.html.erb
@@ -1,40 +1,4 @@
 <section class='data-links'>
   <h2 class="heading-medium">Data links</h2>
-  <table>
-    <tr>
-      <th class="title small">Link to the data</th>
-      <th>Format</th>
-      <th>Last updated</th>
-      <th> </th>
-      <th> </th>
-    </tr>
-    <tbody>
-      <% @dataset.datafiles.each do |datafile| %>
-        <tr>
-          <td class="title small">
-            <%= datafile['name'] %>
-          </td>
-          <%if datafile['format'].blank? %>
-            <td class="unavailable">N/A</td>
-          <% else %>
-            <td><%= datafile['format'].upcase %></td>
-          <% end %>
-
-          <% if datafile['updated_at'].present? %>
-            <td><%= format(datafile['updated_at']) %></td>
-          <% else %>
-            <td class="unavailable">Not available</td>
-          <% end %>
-            <td>
-              <a href="<%= datafile['url'] %>" data-ga-event="datafile-download">
-                <%=format_button(datafile) %>
-              </a>
-            </td>
-            <td>
-              <a href="<%= file_preview_url(datafile['id']) %>"></a>
-            </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+    <%= render 'datafile_table' %>
 </section>

--- a/app/views/datasets/_timeseries_data.html.erb
+++ b/app/views/datasets/_timeseries_data.html.erb
@@ -21,47 +21,7 @@
                 </div>
               </div>
               <div class="year-datasets showHide-content" style="display:none">
-                <table>
-                  <tr>
-                    <th class="title small">Link to the data</th>
-                    <th>Format</th>
-                    <th>Last updated</th>
-                    <th></th>
-                  </tr>
-                  <tbody>
-                  <% datafiles.each do |datafile| %>
-                    <tr>
-                      <td class="title small">
-                        <% if datafile['name'] %> <%= datafile['name'] %>
-                        <% else %> Data Link
-                        <% end %>
-                      </td>
-                      <% if datafile['format'] %>
-                        <td><%= datafile['format'].upcase %></td>
-                      <% else %>
-                        <td>N/A</td>
-                      <% end %>
-                      <% if datafile['updated_at'] %>
-                        <td>
-                          <%= format(datafile['updated_at']) %>
-                        </td>
-                      <% else %>
-                        <td class="unavailable">
-                          Not available
-                      <% end %>
-                      </td>
-                    <td>
-                      <a href="<%= datafile['url'] %>" data-ga-event="datafile-download">
-                        <%=format_button(datafile) %>
-                      </a>
-                    </td>
-                    <td>
-                      <a href="<%= file_preview_url(datafile['id']) %>"></a>
-                    </td>
-                    </tr>
-                  <% end %>
-                  </tbody>
-                </table>
+                <%= render 'datafile_table' %>
               </div>
           <% end %>
           </li>

--- a/app/views/datasets/preview.html.erb
+++ b/app/views/datasets/preview.html.erb
@@ -1,7 +1,7 @@
 <% if @content_type == 'CSV' %>
     <div class="grid-row">
     <div class="column-full">
-      <a href="/dataset/land-registry-monthly-price-paid-data" class="link-back">Back to dataset</a>
+      <a href="<%= dataset_path(name_of(@dataset)) %>" class="link-back">Back to dataset</a>
       <h1 class="heading-large">
           <%= @preview['meta']['dataset_title'] %>
           <span class="heading-secondary dgu-home-spacer__bottom"><%= @preview['meta']['datafile_name'] %></span>

--- a/app/views/datasets/preview.html.erb
+++ b/app/views/datasets/preview.html.erb
@@ -4,22 +4,22 @@
       <a href="/dataset/land-registry-monthly-price-paid-data" class="link-back">Back to dataset</a>
       <h1 class="heading-large">
           <%= @preview['meta']['dataset_title'] %>
-          <span class="heading-secondary"><%= @preview['meta']['datafile_name'] %></span>
+          <span class="heading-secondary dgu-home-spacer__bottom"><%= @preview['meta']['datafile_name'] %></span>
       </h1>
 
       <a class="button" href="<%= @preview['meta']['datafile_link'] %>">Download this file</a>
-      <section class="preview">
+      <section class="table__preview">
           <table>
             <tr><thead>
                 <% @preview['content']['body'].first.each do |col| %>
-                    <th><%= col %></th> 
+                    <th><%= col %></th>
                 <% end %>
             </tr></thead>
             <tbody>
                 <% @preview['content']['body'].drop(1).each do |row| %>
                     <tr>
                         <% row.each do |col| %>
-                            <td><%= col %></td> 
+                            <td><%= col %></td>
                         <% end %>
                     </tr>
                 <% end %>

--- a/app/views/datasets/preview.html.erb
+++ b/app/views/datasets/preview.html.erb
@@ -1,6 +1,6 @@
 <% if @content_type == 'CSV' %>
     <div class="grid-row">
-    <div class="column-full">
+    <div class="column-two-thirds">
       <a href="<%= dataset_path(name_of(@dataset)) %>" class="link-back">Back to dataset</a>
       <h1 class="heading-large">
           <%= @preview['meta']['dataset_title'] %>
@@ -8,6 +8,8 @@
       </h1>
 
       <a class="button" href="<%= @preview['meta']['datafile_link'] %>">Download this file</a>
+    </div>
+    <div class = 'column-full'>
       <section class="table__preview">
           <table>
             <tr><thead>

--- a/spec/helpers/datasets_helper_spec.rb
+++ b/spec/helpers/datasets_helper_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+# The dataset objects used below are defined in support/dataset_spec_builder.rb
+
 describe DatasetsHelper, type: :helper do
   it 'groups time series data by year' do
     expect(helper.group_by_year(UNFORMATTED_DATASETS_MULTIYEAR)).to eql FORMATTED_DATASETS
@@ -13,13 +15,20 @@ describe DatasetsHelper, type: :helper do
     expect(helper.timeseries_data?(UNFORMATTED_DATASETS_SINGLEYEAR)).to be false
   end
 
-  it 'displays view if the datafile is html' do
-    HTML_DATAFILE = DATA_FILES_WITH_START_AND_ENDDATE[0]
-    expect(helper.format_button(HTML_DATAFILE)).to eql 'View'
+  it 'returns html if datafile is a webpage' do
+    expect(helper.link_type(DATA_FILES_WITH_START_AND_ENDDATE[0])).to be :html
   end
 
-  it 'displays download if the datafile is not HTML' do
-    CSV_DATAFILE = DATA_FILES_WITH_START_AND_ENDDATE[1]
-    expect(helper.format_button(CSV_DATAFILE)).to eql 'Download'
+  it 'returns :no_preview if datafile has nil or blank format' do
+    expect(helper.link_type(DATAFILES_WITHOUT_START_AND_ENDDATE[0])).to be :no_preview
   end
+
+  it 'returns no_preview if datafile has no preview' do
+    expect(helper.link_type(DATA_FILES_WITH_START_AND_ENDDATE[1])).to be :no_preview
+  end
+
+  fit 'returns preview if datafile has a preview' do
+    expect(helper.link_type(CSV_DATAFILE)).to be :preview
+  end
+
 end

--- a/spec/support/dataset_spec_builder.rb
+++ b/spec/support/dataset_spec_builder.rb
@@ -232,3 +232,4 @@ FORMATTED_DATASETS = {
          'start_year' => ''
         }]
 }
+CSV_DATAFILE = { 'url' => 'https://find-data-beta.herokuapp.com/file/9/preview'}


### PR DESCRIPTION
@govuklaurence 

This PR

- Styles the preview page NB line count is still to be added. See [here](https://github.com/datagovuk/find_data_beta/pull/224/files)
- Restructures table as per https://trello.com/c/u90lefkO/423-datafiles-table-styling

new layout:

<img width="760" alt="screen shot 2017-09-04 at 22 37 20" src="https://user-images.githubusercontent.com/17908089/30038890-b0290724-91c1-11e7-83f7-d98b0c823cba.png">

- Creates a back to dataset link based on the id preview['meta']['dataset_id']
- NB as discussed on slack, there is a problem with the IDs that are coming over from publish:
  - The preview link takes you to a preview that doesn't belong to that datafile.
  - The back to dataset link takes you to a dataset that is not the parent of that datafile.

- This is safe to be merged into master now, no previews will be shown as `not available` will show for all non-html file types