### PR TITLE
Implement breadcrumb styles locally instead of via the front end toolkit

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -322,3 +322,47 @@ section .year-expand {
 .result {
   margin-top: 30px;
 }
+
+// Breadcrumb - this has been replicated here as could not get it to work via the frontend-toolkit gem
+
+.datagov_breadcrumb {
+
+  padding-top: 0.75em;
+  padding-bottom: 0.75em;
+
+  ol {
+    @extend %contain-floats;
+  }
+
+  li {
+    @include core-16;
+    float: left;
+
+    background-image: image-url("separator.png");
+
+    @include device-pixel-ratio() {
+      background-image: image-url("separator-2x.png");
+      background-size: 6px 11px;
+    }
+
+    background-position: 0% 50%;
+    background-repeat: no-repeat;
+
+    list-style: none;
+
+    margin-left: 0.6em;
+    margin-bottom: 0.4em;
+    padding-left: 0.9em;
+
+    &:first-child {
+      background-image: none;
+      margin-left: 0;
+      padding-left: 0;
+    }
+
+  }
+
+  a {
+    color: $text-colour;
+  }
+}

--- a/app/views/datasets/_breadcrumb.html.erb
+++ b/app/views/datasets/_breadcrumb.html.erb
@@ -1,8 +1,8 @@
 <div class="grid-row">
   <!-- Only display breadcrumb if the referrer host matches the application host  -->
   <div class="column-full">
-    <div class="breadcrumbs">
-      <ol role="breadcrumbs">
+    <div class="datagov_breadcrumb">
+      <ol role="breadcrumb">
         <li>
           <%= link_to 'Home', root_path %>
         </li>

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -11,7 +11,7 @@ describe DatasetsController, type: :controller do
 
         create_dataset_and_visit
 
-        expect(response.body).to have_css('div.breadcrumbs')
+        expect(response.body).to have_css('div.datagov_breadcrumb')
         expect(response.body).to_not have_css('li', text: 'Ministry of Defence')
         expect(response.body).to have_css('li', text: 'Search')
       end
@@ -23,7 +23,7 @@ describe DatasetsController, type: :controller do
 
         create_dataset_and_visit
 
-        expect(response.body).to have_css('div.breadcrumbs')
+        expect(response.body).to have_css('div.datagov_breadcrumb')
         expect(response.body).to have_css('li', text: 'Ministry of Defence')
         expect(response.body).to_not have_css('li', text: 'Search')
       end


### PR DESCRIPTION
Implement a breadcrumb styles locally.

Was unable to get breadcrumb chevron to load via the frontend-toolkit gem. Possibly an issue with one of the url helpers? Will raise this with patterns and tools team who maintain the gem.