### PR TITLE
Use dotenv to manage env vars in development

### DIFF
--- a/.example-env
+++ b/.example-env
@@ -1,0 +1,3 @@
+PUBLISH_URL="https://username:password@publish-data-beta.herokuapp.com"
+SECRET_KEY_BASE="secret" # random string for development
+ES_HOST="127.0.0.1:9200"

--- a/.example-env
+++ b/.example-env
@@ -1,2 +1,2 @@
-PUBLISH_URL="https://username:password@publish-data-beta.herokuapp.com"
+PUBLISH_URL="https://www.example-publish-app.com"
 SECRET_KEY_BASE="secret" # random string for development

--- a/.example-env
+++ b/.example-env
@@ -1,3 +1,2 @@
 PUBLISH_URL="https://username:password@publish-data-beta.herokuapp.com"
 SECRET_KEY_BASE="secret" # random string for development
-ES_HOST="127.0.0.1:9200"

--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,8 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.6'
   gem 'rspec', '~> 3.6'
   gem 'webmock'
+  gem 'dotenv-rails', groups: [:development, :test]
 end
-
 
 group :development do
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,9 @@ GEM
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     elasticsearch (5.0.4)
       elasticsearch-api (= 5.0.4)
       elasticsearch-transport (= 5.0.4)
@@ -392,6 +395,7 @@ DEPENDENCIES
   devise (~> 4.3)
   devise_invitable (~> 1.7.2)
   dotenv (~> 2.2)
+  dotenv-rails
   elasticsearch (~> 5.0.4)
   elasticsearch-dsl (~> 0.1.5)
   elasticsearch-model (~> 5.0.1)
@@ -428,4 +432,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 In order for the app to work, it needs the following environment variables
 to be set.
 
+`mv .example-env .env`
+
 **PUBLISH_URL**
 
 This should be the URL of a working publish data.  If you don't want to run

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,6 +5,7 @@ require 'rails/all'
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+Dotenv::Railtie.load
 
 module FindDataBeta
   class Application < Rails::Application


### PR DESCRIPTION
Just a suggestion here, but I find dotenv to be a practical way to document environment variables and set them locally for development.

https://github.com/bkeepers/dotenv