### PR TITLE
Add Dotenv

### DIFF
--- a/.example-env
+++ b/.example-env
@@ -1,0 +1,2 @@
+PUBLISH_URL="https://www.example-publish-app.com"
+SECRET_KEY_BASE="secret" # random string for development

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.6'
   gem 'rspec', '~> 3.6'
   gem 'webmock'
+  gem 'dotenv-rails', '~> 2.2'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,9 @@ GEM
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     elasticsearch (5.0.4)
       elasticsearch-api (= 5.0.4)
       elasticsearch-transport (= 5.0.4)
@@ -392,6 +395,7 @@ DEPENDENCIES
   devise (~> 4.3)
   devise_invitable (~> 1.7.2)
   dotenv (~> 2.2)
+  dotenv-rails (~> 2.2)
   elasticsearch (~> 5.0.4)
   elasticsearch-dsl (~> 0.1.5)
   elasticsearch-model (~> 5.0.1)
@@ -428,4 +432,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 In order for the app to work, it needs the following environment variables
 to be set.
 
+`mv .example-env .env`
+
 **PUBLISH_URL**
 
 This should be the URL of a working publish data.  If you don't want to run


### PR DESCRIPTION
Follows this revert: https://github.com/datagovuk/find_data_beta/pull/237.

The build was failing on `NameError: uninitialized constant Dotenv`, due to the fact that the gem is only loaded in development and test environments, so the app had no idea what `Dotenv` was in production.

We're ok with the default load order, so there is no need to call `Dotenv::Railtie.load` in `config/application.rb` (https://github.com/datagovuk/find_data_beta/pull/237/files#diff-b1fe55db50c712fef0673345e5b9c0d9L8).

More info: https://github.com/bkeepers/dotenv#note-on-load-order