### PR TITLE
Refactor application controller + routes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,33 +1,3 @@
-require 'private_beta_user'
-
 class ApplicationController < ActionController::Base
-  before_action :authenticate
   protect_from_forgery with: :exception
-end
-
-def authenticate
-
-  return if Rails.env.development? || Rails.env.test?
-
-  if !session.key?('consent') || session[:consent] == false
-    redirect_to use_of_data_path and return
-  end
-
-  authenticate_or_request_with_http_basic('Please sign in with username and password provided to you') do |username, password|
-    httpauth_name = ENV['HTTP_USERNAME']
-    httpauth_pass = ENV['HTTP_PASSWORD']
-
-    admin_login = username == httpauth_name && password == httpauth_pass
-    beta_login = PrivateBetaUser.authenticate?(username, password)
-
-    if beta_login
-      session[:beta_user] = username
-    end
-
-    if admin_login == false && beta_login == false
-      redirect_to '/not_authenticated'
-    else
-      true
-    end
-  end
 end

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -1,0 +1,6 @@
+class ConsentsController < PublicAreaController
+  def confirm
+    session[:consent] = true
+    redirect_to root_path
+  end
+end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,4 @@
-class ErrorsController < ApplicationController
-  skip_before_action :authenticate, only: [:not_authenticated]
-
+class ErrorsController < PublicAreaController
   def not_found
     render(status: 404)
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,14 +1,2 @@
-class HomeController < ApplicationController
-  skip_before_action :authenticate, only: [:consent, :confirm_consent]
-
-  def index
-  end
-
-  def consent
-  end
-
-  def confirm_consent
-    session[:consent] = true
-    redirect_to root_path
-  end
+class HomeController < PublicAreaController
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,2 +1,2 @@
-class HomeController < PublicAreaController
+class HomeController < LoggedAreaController
 end

--- a/app/controllers/logged_area_controller.rb
+++ b/app/controllers/logged_area_controller.rb
@@ -5,11 +5,12 @@ class LoggedAreaController < ApplicationController
   before_action :authenticate
 
   def check_consent
+    return if Rails.env.test?
     redirect_to use_of_data_path if has_not_consented?
   end
 
   def authenticate
-    return if Rails.env.development? || Rails.env.test?
+    return if Rails.env.test?
 
     authenticate_or_request_with_http_basic('Please sign in with username and password provided to you') do |username, password|
       if admin_login?(username, password)

--- a/app/controllers/logged_area_controller.rb
+++ b/app/controllers/logged_area_controller.rb
@@ -1,0 +1,31 @@
+require 'private_beta_user'
+
+class LoggedAreaController < ApplicationController
+  before_action :authenticate
+end
+
+def authenticate
+  return if Rails.env.development? || Rails.env.test?
+
+  if !session.key?('consent') || session[:consent] == false
+    redirect_to use_of_data_path and return
+  end
+
+  authenticate_or_request_with_http_basic('Please sign in with username and password provided to you') do |username, password|
+    httpauth_name = ENV['HTTP_USERNAME']
+    httpauth_pass = ENV['HTTP_PASSWORD']
+
+    admin_login = username == httpauth_name && password == httpauth_pass
+    beta_login = PrivateBetaUser.authenticate?(username, password)
+
+    if beta_login
+      session[:beta_user] = username
+    end
+
+    if admin_login == false && beta_login == false
+      redirect_to '/not_authenticated'
+    else
+      true
+    end
+  end
+end

--- a/app/controllers/logged_area_controller.rb
+++ b/app/controllers/logged_area_controller.rb
@@ -1,31 +1,38 @@
 require 'private_beta_user'
 
 class LoggedAreaController < ApplicationController
+  before_action :check_consent
   before_action :authenticate
-end
 
-def authenticate
-  return if Rails.env.development? || Rails.env.test?
-
-  if !session.key?('consent') || session[:consent] == false
-    redirect_to use_of_data_path and return
+  def check_consent
+    redirect_to use_of_data_path if has_not_consented?
   end
 
-  authenticate_or_request_with_http_basic('Please sign in with username and password provided to you') do |username, password|
-    httpauth_name = ENV['HTTP_USERNAME']
-    httpauth_pass = ENV['HTTP_PASSWORD']
+  def authenticate
+    return if Rails.env.development? || Rails.env.test?
 
-    admin_login = username == httpauth_name && password == httpauth_pass
-    beta_login = PrivateBetaUser.authenticate?(username, password)
+    authenticate_or_request_with_http_basic('Please sign in with username and password provided to you') do |username, password|
+      httpauth_name = ENV['HTTP_USERNAME']
+      httpauth_pass = ENV['HTTP_PASSWORD']
 
-    if beta_login
-      session[:beta_user] = username
+      admin_login = username == httpauth_name && password == httpauth_pass
+      beta_login = PrivateBetaUser.authenticate?(username, password)
+
+      if beta_login
+        session[:beta_user] = username
+      end
+
+      if admin_login == false && beta_login == false
+        redirect_to '/not_authenticated'
+      else
+        true
+      end
     end
+  end
 
-    if admin_login == false && beta_login == false
-      redirect_to '/not_authenticated'
-    else
-      true
-    end
+  private
+
+  def has_not_consented?
+    !session.key?('consent') || session[:consent] == false
   end
 end

--- a/app/controllers/public_area_controller.rb
+++ b/app/controllers/public_area_controller.rb
@@ -1,0 +1,2 @@
+class PublicAreaController < ApplicationController
+end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,4 @@
-class SearchController < ApplicationController
+class SearchController < LoggedAreaController
   include QueryBuilder
 
   def search

--- a/app/views/consents/new.html.erb
+++ b/app/views/consents/new.html.erb
@@ -68,6 +68,6 @@
 </p>
 
 
-      <%= link_to "Sign in to beta.data.gov.uk", confirm_consent_path, class:"button dgu-filters__apply-button" %>
+      <%= link_to "Sign in to beta.data.gov.uk", use_of_data_confirm_path, class:"button dgu-filters__apply-button" %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,18 @@
 Rails.application.routes.draw do
-  match "/404", :to => "errors#not_found", :via => :all
-  match "/500", :to => "errors#internal_server_error", :via => :all
+  root to: 'home#index'
+
+  match "404", to: "errors#not_found", via: :all
+  match "500", to: "errors#internal_server_error", via: :all
 
   get 'search/', to: 'search#search'
   get 'search/tips', to: 'search#tips'
-  resources :datasets, :path => "dataset", param: :name, only: :show
+
   get 'file/:file_id/preview', to: 'datasets#preview', as: :file_preview
 
-  root to: 'home#index'
-  get '/use-of-data', to: 'home#consent'
-  get 'confirm_consent', to: 'home#confirm_consent'
+  get 'use-of-data', to: 'consents#new'
+  get 'use-of-data/confirm', to: 'consents#confirm'
+
   get 'not_authenticated', to: 'errors#not_authenticated'
+
+  resources :datasets, path: "dataset", param: :name, only: :show
 end


### PR DESCRIPTION
### Split into public and private controllers

Setting before_action :authenticate in ApplicationController sets a global default that we have to manually skip every time we write a public controller.

Having controllers for the private areas of the site inherit from a `PrivateAreaController` allows us to avoid having to skip authentication for the public areas of the app.

### ConsentsController

When a user consents to the terms of usage, he in effect creates a new consent. A `ConsentsController#new` allows us to express this in a RESTful way, and clean up the `HomeController`.

### Clean up `authenticate`

* extract local variables to private helper methods
* enforce same level of abstraction