### PR TITLE
Use authentication helper to log in test users

### DIFF
--- a/app/controllers/logged_area_controller.rb
+++ b/app/controllers/logged_area_controller.rb
@@ -10,8 +10,6 @@ class LoggedAreaController < ApplicationController
   end
 
   def authenticate
-    return if Rails.env.test?
-
     authenticate_or_request_with_http_basic('Please sign in with username and password provided to you') do |username, password|
       if admin_login?(username, password)
         return true

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -1,6 +1,5 @@
 require 'rails_helper'
 
-
 describe DatasetsController, type: :controller do
   render_views
 
@@ -9,6 +8,7 @@ describe DatasetsController, type: :controller do
       it 'will not display the publisher name if the referrer host name is the application host name' do
         request.env['HTTP_REFERER'] = 'http://test.host/search?q=fancypants'
 
+        authenticate
         create_dataset_and_visit
 
         expect(response.body).to have_css('div.datagov_breadcrumb')
@@ -21,6 +21,7 @@ describe DatasetsController, type: :controller do
       it 'will display the publisher name if the user has visited the search page from outside the application' do
         request.env['HTTP_REFERER'] = 'http://unknown.host/search?q=fancypants'
 
+        authenticate
         create_dataset_and_visit
 
         expect(response.body).to have_css('div.datagov_breadcrumb')
@@ -29,16 +30,4 @@ describe DatasetsController, type: :controller do
       end
     end
   end
-end
-
-def create_dataset_and_visit
-  slug = 'a-nice-dataset'
-  dataset = DatasetBuilder.new
-                .with_name(slug)
-                .with_title('A nice dataset')
-                .build
-
-  index([dataset])
-  get :show, params: {name: slug}
-
 end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 describe SearchController, type: :controller do
   context 'Filtering by location' do
     render_views
@@ -28,6 +30,8 @@ describe SearchController, type: :controller do
 
 
       index([first_dataset, second_dataset, third_dataset])
+
+      authenticate
 
       get :search, params: {location: 'Auckland'}
 

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 feature 'Dataset page', elasticsearch: true do
-
   before(:each) do
+    authenticate_browser
+
     stub_request(:any, FETCH_PREVIEW_URL).
       to_return(status: 200)
   end

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -1,8 +1,11 @@
 # coding: utf-8
 require 'rails_helper'
 
-
 feature 'Search page', elasticsearch: true do
+  before(:each) do
+    authenticate_browser
+  end
+
   scenario 'Displays a not found message when a search returns 0 results' do
     query = 'interesting dataset'
 

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -1,0 +1,7 @@
+def authenticate_browser
+  page.driver.browser.authorize(ENV['HTTP_USERNAME'], ENV['HTTP_PASSWORD'])
+end
+
+def authenticate
+  @request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(ENV['HTTP_USERNAME'], ENV['HTTP_PASSWORD'])
+end

--- a/spec/support/dataset_spec_helper.rb
+++ b/spec/support/dataset_spec_helper.rb
@@ -16,6 +16,17 @@ def index_and_visit(dataset)
   visit "/dataset/#{dataset[:name]}"
 end
 
+def create_dataset_and_visit
+  slug = 'a-nice-dataset'
+  dataset = DatasetBuilder.new
+                .with_name(slug)
+                .with_title('A nice dataset')
+                .build
+
+  index([dataset])
+  get :show, params: {name: slug}
+end
+
 def search_for(query)
   visit '/'
   within '#content' do


### PR DESCRIPTION
This PR creates an `authenticate` and `authenticate_browser` helpers for use in controller and feature specs. That way, we can avoid adding checks for `Rails.env.test?` in our code.