### PR TITLE
Fix datafiles group by year on dataset page

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -6,7 +6,7 @@ class DatasetsController < LoggedAreaController
     begin
       query = get_query(name: params[:name])
       @dataset = Dataset.get(query)
-      @timeseries_datafiles = @dataset.timeseries_datafiles.group_by(&:start_year)
+      @timeseries_datafiles = @dataset.timeseries_datafiles
       @non_timeseries_datafiles = @dataset.non_timeseries_datafiles
       raise 'Metadata missing' if @dataset.title.blank?
     rescue => e

--- a/app/models/datafile.rb
+++ b/app/models/datafile.rb
@@ -14,7 +14,7 @@ class Datafile
   end
 
   def start_year
-    return "" if start_date.blank?
+    return "Non-timeseries" if start_date.blank?
     Time.parse(start_date).year
   end
 

--- a/app/views/datasets/_non_timeseries_data.html.erb
+++ b/app/views/datasets/_non_timeseries_data.html.erb
@@ -1,4 +1,1 @@
-<section class="dgu-datalinks">
-  <h2 class="heading-medium">Data links</h2>
-  <%= render partial: 'datafile_table', locals: { datafiles: datafiles } %>
-</section>
+<%= render partial: 'datafile_table', locals: { datafiles: datafiles } %>

--- a/app/views/datasets/_timeseries_data.html.erb
+++ b/app/views/datasets/_timeseries_data.html.erb
@@ -1,20 +1,20 @@
 <ul>
   <% datafiles.group_by(&:start_year).each do |year, datafiles| %>
     <li class="showHide">
-    <div class="year-expand showHide-control">
-      <h3 class="heading-small">
-        <button class="button secondary">
-          <%= year %>
-        </button>
-      </h3>
-      <div>
-        <button class="expand button secondary">+</button>
+      <div class="year-expand showHide-control">
+        <h3 class="heading-small">
+          <button class="button secondary">
+            <%= year %>
+          </button>
+        </h3>
+        <div>
+          <button class="expand button secondary">+</button>
+        </div>
       </div>
-    </div>
-    <div class="year-datasets showHide-content" style="display:none">
-      <%= render partial: 'datafile_table', locals: { datafiles: datafiles } %>
-    </div>
-  <% end %>
+      <div class="year-datasets showHide-content" style="display:none">
+        <%= render partial: 'datafile_table', locals: { datafiles: datafiles } %>
+      </div>
+    <% end %>
   </li>
 </ul>
 

--- a/app/views/datasets/_timeseries_data.html.erb
+++ b/app/views/datasets/_timeseries_data.html.erb
@@ -11,7 +11,7 @@
           <button class="expand button secondary">+</button>
         </div>
       </div>
-      <div class="year-datasets showHide-content" style="display:none">
+      <div class="showHide-content" style="display:none">
         <%= render partial: 'datafile_table', locals: { datafiles: datafiles } %>
       </div>
     <% end %>

--- a/app/views/datasets/_timeseries_data.html.erb
+++ b/app/views/datasets/_timeseries_data.html.erb
@@ -1,33 +1,21 @@
-<section>
-  <div class="grid-row">
-    <div class="column-full">
-      <section class="dgu-datalinks">
-        <!-- accordions for time series datasets -->
-        <h2 class="heading-medium">Data links
-          <span class="showHide-open-all">Open all</span>
-        </h2>
-        <div class="breaker"></div>
-        <ul>
-          <% datafiles.each do |year, datafiles| %>
-            <li class="showHide">
-              <div class="year-expand showHide-control">
-                <h3 class="heading-small">
-                  <button class="button secondary">
-                    <%= year %>
-                  </button>
-                </h3>
-                <div>
-                  <button class="expand button secondary">+</button>
-                </div>
-              </div>
-              <div class="year-datasets showHide-content" style="display:none">
-                <%= render partial: 'datafile_table', locals: { datafiles: datafiles } %>
-              </div>
-          <% end %>
-          </li>
-        </ul>
-        <input class="button dgu-datalinks__download" type="submit" value="Download all">
-      </section>
+<ul>
+  <% datafiles.group_by(&:start_year).each do |year, datafiles| %>
+    <li class="showHide">
+    <div class="year-expand showHide-control">
+      <h3 class="heading-small">
+        <button class="button secondary">
+          <%= year %>
+        </button>
+      </h3>
+      <div>
+        <button class="expand button secondary">+</button>
+      </div>
     </div>
-  </div>
-</section>
+    <div class="year-datasets showHide-content" style="display:none">
+      <%= render partial: 'datafile_table', locals: { datafiles: datafiles } %>
+    </div>
+  <% end %>
+  </li>
+</ul>
+
+<input class="button dgu-datalinks__download" type="submit" value="Download all">

--- a/app/views/datasets/_timeseries_data.html.erb
+++ b/app/views/datasets/_timeseries_data.html.erb
@@ -2,7 +2,7 @@
   <% datafiles.group_by(&:start_year).each do |year, datafiles| %>
     <li class="showHide">
       <div class="year-expand showHide-control">
-        <h3 class="heading-small">
+        <h3 class="dgu-datalinks__year heading-small">
           <button class="button secondary">
             <%= year %>
           </button>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -3,8 +3,26 @@
   <%= render "meta_data" %>
 
   <% unless @dataset.datafiles.empty? %>
-    <%= render partial: "timeseries_data", locals: { datafiles: @timeseries_datafiles } %>
-    <%= render partial: "non_timeseries_data", locals: { datafiles: @non_timeseries_datafiles } %>
+    <div class="grid-row">
+      <div class="column-full">
+        <section class="dgu-datalinks">
+          <h2 class="heading-medium">Data links
+            <% if @timeseries_datafiles.present? %>
+              <!-- accordions for time series datasets -->
+              <span class="showHide-open-all">Open all</span>
+            <% end %>
+          </h2>
+
+          <div class="breaker"></div>
+
+          <% if @timeseries_datafiles.present? %>
+            <%= render partial: "timeseries_data", locals: { datafiles: @dataset.datafiles } %>
+          <% else %>
+            <%= render partial: "non_timeseries_data", locals: { datafiles: @dataset.datafiles } %>
+          <% end %>
+        </section>
+      </div>
+    </div>
   <% end %>
 
   <% if @dataset.notes.present? %>
@@ -18,5 +36,4 @@
   <% if @dataset.organisation['contact_email'].present? %>
     <%= render "contact" %>
   <% end %>
-
 </main>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -13,8 +13,6 @@
             <% end %>
           </h2>
 
-          <div class="breaker"></div>
-
           <% if @timeseries_datafiles.present? %>
             <%= render partial: "timeseries_data", locals: { datafiles: @dataset.datafiles } %>
           <% else %>

--- a/spec/features/dataset_show_page_spec.rb
+++ b/spec/features/dataset_show_page_spec.rb
@@ -191,4 +191,88 @@ feature 'Dataset page', elasticsearch: true do
       expect(page).to_not have_css('h2', text: 'Contact')
     end
   end
+
+  feature 'Datafiles' do
+    scenario 'are grouped by year when they contain timeseries datafiles' do
+      timeseries_and_non_timeseries = [
+        {
+          id: 1,
+          url: "http://www.foobar.com",
+          name: "Datafile 1",
+          start_date: "2000/01/01",
+          end_date: "2000/12/12",
+          updated_at: "2000/01/01"
+        },
+        {
+          id: 2,
+          url: "http://www.foobar.com",
+          name: "Datafile 2",
+          start_date: "2001/01/01",
+          end_date: "2001/12/12",
+          updated_at: "2001/01/01"
+        },
+        {
+          id: 3,
+          url: "http://www.foobar.com",
+          name: "Datafile 3",
+          start_date: "2001/01/01",
+          end_date: "2001/12/12",
+          updated_at: "2001/01/01"
+        },
+        {
+          id: 4,
+          url: "http://www.foobar.com",
+          name: "Datafile 3",
+          start_date: nil,
+          end_date: "2001/12/12",
+          updated_at: "2001/01/01"
+        }
+      ]
+
+      dataset = DatasetBuilder.new
+        .with_datafiles(timeseries_and_non_timeseries)
+        .build
+
+      index_and_visit(dataset)
+
+      expect(page).to have_css(".dgu-datalinks__year", count: 3)
+    end
+
+    scenario 'are not grouped when they contain non timeseries datafiles' do
+      non_timeseries_data_files = [
+        {
+          id: 1,
+          url: "http://www.foobar.com",
+          name: "Datafile 1",
+          start_date: nil,
+          end_date: "2000/12/12",
+          updated_at: "2000/01/01"
+        },
+        {
+          id: 2,
+          url: "http://www.foobar.com",
+          name: "Datafile 2",
+          start_date: nil,
+          end_date: "2001/12/12",
+          updated_at: "2001/01/01"
+        },
+        {
+          id: 3,
+          url: "http://www.foobar.com",
+          name: "Datafile 3",
+          start_date: nil,
+          end_date: "2001/12/12",
+          updated_at: "2001/01/01"
+        }
+      ]
+
+      dataset = DatasetBuilder.new
+        .with_datafiles(non_timeseries_data_files)
+        .build
+
+      index_and_visit(dataset)
+
+      expect(page).to have_css(".dgu-datalinks__year", count: 0)
+    end
+  end
 end


### PR DESCRIPTION
@BlancaTortajada When we have both timeseries and non-timeseries datafiles, it looks odd/confusing to group timeseries datafiles under a header (the year) but not group the non-timeseries datafiles.

So here is what this pull request makes it look like for the different cases:

### Timeseries datafiles only

![timeseries](https://user-images.githubusercontent.com/3141541/30483665-93c0ce80-9a1f-11e7-9560-a08997683820.png)

### Non timeseries datafiles only

![non](https://user-images.githubusercontent.com/3141541/30483688-a23cae0c-9a1f-11e7-967f-d4f09bf9169e.png)

### Timeseries + non-timeseries datafiles

![group](https://user-images.githubusercontent.com/3141541/30483632-74884f84-9a1f-11e7-9b5d-cc1d88ed8ccd.png)

Also, it's unclear to me in what case we want to show the "Download all" button.

We currently show it when:

* there are only timeseries datafiles
* there are both timeseries and non-timeseries datafiles

We do not show it when we have non timeseries datafiles only.

Not sure if that's the expected behaviour.

Could you please clarify?