### PR TITLE
Preview page improvements

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -14,7 +14,6 @@ class DatasetsController < LoggedAreaController
   def preview
     @dataset = Dataset.get_by(name: params[:name])
     @datafile = @dataset.datafiles.find { |f| f.uuid == params[:uuid] }
-    @preview = @datafile.preview
   end
 
   private

--- a/app/models/datafile.rb
+++ b/app/models/datafile.rb
@@ -42,6 +42,6 @@ class Datafile
   end
 
   def preview
-    Preview.new(url: url, format: format).render
+    @preview ||= Preview.new(url: url, format: format)
   end
 end

--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -11,8 +11,12 @@ class Preview
 
   def estimated_lines
     total_file_size = fetch_headers['content-length'].to_i
-    average_line_size = 1024/line_count
-    total_file_size / average_line_size
+    if line_count > 0
+      average_line_size = 1024/line_count
+      total_file_size / average_line_size
+    else
+      0
+    end
   end
 
   def line_count

--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -9,18 +9,8 @@ class Preview
     @body = render
   end
 
-  def estimated_lines
-    total_file_size = fetch_headers['content-length'].to_i
-    if line_count > 0
-      average_line_size = 1024/line_count
-      total_file_size / average_line_size
-    else
-      0
-    end
-  end
-
   def line_count
-    @body.length
+    rows.length
   end
 
   def headers
@@ -28,7 +18,7 @@ class Preview
   end
 
   def rows
-    body.drop(1)
+    body.drop(1).take(4)
   end
 
   def exists?

--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -1,18 +1,41 @@
 require 'csv'
 
 class Preview
-  attr_reader :url, :format
+  attr_reader :url, :format, :body
 
   def initialize(url:, format:)
     @url = url
     @format = format
+    @body = render
   end
 
-  def render
-    csv? ? CSV.parse(fetch_raw) : []
+  def estimated_lines
+    total_file_size = fetch_headers['content-length'].to_i
+    average_line_size = 1024/line_count
+    total_file_size / average_line_size
+  end
+
+  def line_count
+    @body.length
+  end
+
+  def headers
+    body.first
+  end
+
+  def rows
+    body.drop(1)
+  end
+
+  def exists?
+    body.present?
   end
 
   private
+
+  def render
+    csv? ? CSV.parse(fetch_raw).reject{ |l| l.empty? } : []
+  end
 
   def fetch_raw
     connection = Faraday.new do |faraday|
@@ -27,9 +50,31 @@ class Preview
         request.url(url)
         request.options.timeout = 5
       end
-      response.body.rpartition("\n")[0]
+
+      raw_body = response.body.gsub("\r", "\n")
+      raw_body.rpartition("\n")[0]
+
     rescue
       ""
+    end
+  end
+
+  def fetch_headers
+    connection = Faraday.new do |faraday|
+      faraday.use FaradayMiddleware::FollowRedirects, limit: 3
+      faraday.adapter :net_http
+    end
+
+    begin
+      response = connection.head do |request|
+        request.url(url)
+        request.options.timeout = 5
+      end
+
+      response.headers
+
+    rescue
+      {}
     end
   end
 

--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -44,31 +44,15 @@ class Preview
         request.url(url)
         request.options.timeout = 5
       end
-
-      raw_body = response.body.gsub("\r", "\n")
-      raw_body.rpartition("\n")[0]
-
+      # some datafiles have a format type of CSV but are HTML links. Joy.
+      if response.body[1..100].include? "DOCTYPE"
+        ""
+      else
+        raw_body = response.body.gsub("\r", "\n")
+        raw_body.rpartition("\n")[0]
+      end
     rescue
       ""
-    end
-  end
-
-  def fetch_headers
-    connection = Faraday.new do |faraday|
-      faraday.use FaradayMiddleware::FollowRedirects, limit: 3
-      faraday.adapter :net_http
-    end
-
-    begin
-      response = connection.head do |request|
-        request.url(url)
-        request.options.timeout = 5
-      end
-
-      response.headers
-
-    rescue
-      {}
     end
   end
 

--- a/app/views/datasets/_datafile_table.html.erb
+++ b/app/views/datasets/_datafile_table.html.erb
@@ -19,7 +19,7 @@
         <% else %>
           <td><%= datafile.format.upcase %>
           <% if datafile.size %>
-            (<%= datafile.size %> kB)
+            (<%= datafile.size.number_to_human_size %> )
           <% end %>
           </td>
         <% end %>

--- a/app/views/datasets/preview.html.erb
+++ b/app/views/datasets/preview.html.erb
@@ -5,7 +5,9 @@
       <%= @dataset.title %>
       <span class="heading-secondary dgu-home-spacer__bottom"><%= @datafile.name %></span>
     </h1>
-    <p>You're previewing <%= @datafile.preview.line_count %> rows out of the total <%= @datafile.preview.estimated_lines %> in this file.</p>
+    <% if @datafile.csv? && @datafile.preview.exists? %>
+      <p>You're previewing the first <%= @datafile.preview.line_count %> rows of this file.</p>
+    <% end %>
     <a class="button" href="<%= @datafile.url %>"><%= t('.download_file') %></a>
   </div>
   <div class = 'column-full'>

--- a/app/views/datasets/preview.html.erb
+++ b/app/views/datasets/preview.html.erb
@@ -5,22 +5,22 @@
       <%= @dataset.title %>
       <span class="heading-secondary dgu-home-spacer__bottom"><%= @datafile.name %></span>
     </h1>
-
+    <p>You're previewing <%= @datafile.preview.line_count %> rows out of the total <%= @datafile.preview.estimated_lines %> in this file.</p>
     <a class="button" href="<%= @datafile.url %>"><%= t('.download_file') %></a>
   </div>
   <div class = 'column-full'>
     <section class="dgu-datafile-preview">
-      <% if @datafile.csv? && @datafile.preview.present? %>
+      <% if @datafile.csv? && @datafile.preview.exists? %>
         <table>
           <thead>
             <tr>
-              <% @datafile.preview.first.each do |col| %>
+              <% @datafile.preview.headers.each do |col| %>
                 <th><%= col %></th>
               <% end %>
             </tr>
           </thead>
           <tbody>
-            <% @datafile.preview.drop(1).each do |row| %>
+            <% @datafile.preview.rows.each do |row| %>
               <tr>
                 <% row.each do |col| %>
                   <td><%= col %></td>


### PR DESCRIPTION
This PR relates to [this trello ticket](https://trello.com/c/GsqjYnqE/12-display-line-count-information)

- As per Blanca's request, we no longer need to display "You are previewing x lines out of a total y".
- Also fixes a bug (https://find-data-beta.cloudapps.digital/dataset/public-toilets-st-helens-council-csv) caused by datafiles with a file type of CSV when they are in fact HTML. Now they display the correct preview empty state design.
- I have only come across this bug once, so I've not checked for all other scenarios at this stage.