### PR TITLE
If env var isn't set then don't do httpauth

### DIFF
--- a/app/controllers/logged_area_controller.rb
+++ b/app/controllers/logged_area_controller.rb
@@ -10,7 +10,7 @@ class LoggedAreaController < ApplicationController
   end
 
   def authenticate
-    return if Rails.env.test?
+    return if Rails.env.test? || ENV.fetch('PRIVATE_BETA_USER_SALT', nil)
 
     authenticate_or_request_with_http_basic('Please sign in with username and password provided to you') do |username, password|
       if admin_login?(username, password)


### PR DESCRIPTION
In order to make it possible to run end-to-end testing, we need to be able to disable http basic auth (because tests frameworks don't cope well with it).