### PR TITLE
Some datasets don't have last_updated_at

### DIFF
--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -62,7 +62,11 @@
                   <dt> <%= t('.meta_data_box.published_by') %>:</dt>
                   <dd> <%= link_to d.organisation['title'], search_path(publisher: d.organisation['title']) %></dd>
                   <dt> <%= t('.meta_data_box.last_updated') %>:</dt>
-                  <dd> <%= format(d.last_updated_at) %></dd>
+                  <% if d.last_updated_at.present? %>
+                    <dd> <%= format(d.last_updated_at) %></dd>
+                  <% else %>
+                    <dd class="dgu-unavailable"> <%= t('.meta_data_box.not_applicable') %></dd>
+                  <% end %>
                   <dt> <%= t('.meta_data_box.geo_area') %>:</dt>
                   <% if d.location1.present? %>
                     <dd><%= d.location1 %></dd>


### PR DESCRIPTION
It shouldn't be possible, but currently happens with the way we currently index datasets on ES.
Even if we make sure it never happens in the future, it's good practice to handle bad or missing input data.