### PR TITLE
Fix bug on location filter

### DIFF
--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -151,7 +151,7 @@ module Search
     def self.location_filter(location)
       {
         match: {
-          "location1.raw": location
+          "location1": location
         }
       }
     end


### PR DESCRIPTION
This PR fixes a bug where filtering by "wales" would only bring back results with a location of "wales", but would not bring back results with a location of "england, wales" 

